### PR TITLE
Add `.gitignore` and enable specification of `storage_id` and `serialization_format` in Reader constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/nml_bag/example.py
+++ b/nml_bag/example.py
@@ -68,7 +68,7 @@ def main(bag_name='bag_test', topic='test'):
     write_bag_file(bag_path, topic=topic)
     
     # Initialize a bag reader.
-    reader = Reader(f'{bag_path}{sep}{bag_name}_0.db3')
+    reader = Reader(f'{bag_path}{sep}{bag_name}_0.db3', storage_id='sqlite3', serialization_format='cdr')
     
     # Print the topics.
     print(f'The bag contains the following topics:')

--- a/nml_bag/reader.py
+++ b/nml_bag/reader.py
@@ -124,7 +124,7 @@ class Reader(SequentialReader):
     >>> writer.write('test_topic', 
     ...              serialize_message(message), 
     ...              clock.now().nanoseconds)
-    >>> reader = Reader(f'{bag_path}{sep}bag_test_0.db3')
+    >>> reader = Reader(f'{bag_path}{sep}bag_test_0.db3', storage_id='sqlite3', serialization_format='cdr')
     >>> reader.topics
     ['test_topic']
     >>> reader.type_map
@@ -139,9 +139,9 @@ class Reader(SequentialReader):
                 #write-the-python-node
     """
     
-    def __init__(self, filepath=None, topics=[], **kwargs):
+    def __init__(self, filepath=None, topics=[], storage_id='sqlite3', serialization_format='cdr', **kwargs):
         super().__init__(**kwargs) # SequentialReader
-        if filepath: self.open(filepath)
+        if filepath: self.open(filepath, storage_id=storage_id, serialization_format=serialization_format)
         if topics: self.set_filter(topics)
         
     def open(self, filepath, storage_id='sqlite3', serialization_format='cdr'):
@@ -151,8 +151,10 @@ class Reader(SequentialReader):
         ----------
         filepath : str
             Filesystem path to the bag file to open.
-        storage_id
-        serialization_format
+        storage_id: str
+            The storage plugin to use. See the ROS2 bag documentation for more information.
+        serialization_format: str
+            The serialization format to use. See the ROS2 bag documentation for more information.
         
         Notes
         -----
@@ -166,9 +168,9 @@ class Reader(SequentialReader):
         .. _CDR: https://en.wikipedia.org/wiki/Common_Data_Representation
 
         """
-        storage_options = StorageOptions(uri=filepath, storage_id='sqlite3')
-        converter_options = ConverterOptions(input_serialization_format='cdr',
-                                             output_serialization_format='cdr')
+        storage_options = StorageOptions(uri=filepath, storage_id=storage_id)
+        converter_options = ConverterOptions(input_serialization_format=serialization_format,
+                                             output_serialization_format=serialization_format)
         super().open(storage_options, converter_options)
         #self._records = list(self)
         


### PR DESCRIPTION
- When installing the package, `build` folders are created. These should be ignored by git.
- It is quite easy to add functionality to read rosbags stored with the `mcap` plugin. We need to allow users to specify these options though.